### PR TITLE
fix: max_index and wallis_product functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VSCODE
+.vscode

--- a/numpy_questions.py
+++ b/numpy_questions.py
@@ -15,10 +15,11 @@ We also ask to respect the pep8 convention: https://pep8.org.
 This will be enforced with `flake8`. You can check that there is no flake8
 errors by calling `flake8` at the root of the repo.
 """
+from typing import Tuple
 import numpy as np
 
 
-def max_index(X):
+def max_index(X: np.ndarray) -> Tuple[int, int]:
     """Return the index of the maximum in a numpy array.
 
     Parameters
@@ -40,12 +41,15 @@ def max_index(X):
     i = 0
     j = 0
 
-    # TODO
-
+    if not isinstance(X, np.ndarray):
+        raise ValueError("The input is not a  numpy array.")
+    elif not len(X.shape) == 2:
+        raise ValueError("The input is not a numpy array")
+    i, j = np.unravel_index(np.argmax(X, axis=None), X.shape)
     return i, j
 
 
-def wallis_product(n_terms):
+def wallis_product(n_terms: int) -> float:
     """Implement the Wallis product to compute an approximation of pi.
 
     See:
@@ -62,6 +66,14 @@ def wallis_product(n_terms):
     pi : float
         The approximation of order `n_terms` of pi using the Wallis product.
     """
-    # XXX : The n_terms is an int that corresponds to the number of
-    # terms in the product. For example 10000.
-    return 0.
+    # Handle the case where n_terms is 0 (convention).
+    if n_terms == 0:
+        return 2
+
+    # Calculate the Wallis product
+    terms = np.arange(1, n_terms + 1, dtype="int64")
+    numerators = 4 * terms**2
+    fractions = numerators / (numerators - 1)
+    pi_approximation = np.prod(fractions) * 2
+
+    return pi_approximation


### PR DESCRIPTION

## `numpy_questions.py`
Fix the `max_index` and `wallis_product` functions to pass the tests. Additionally, enhance code readability and maintainability through the following changes:

The `max_index` function is designed to find the indices of the maximum value in a 2D numpy array. Here's a breakdown of the implementation:
- Type hints (annotations) have been added to the function signature to specify that the input parameter `X` is expected to be a numpy array of shape (n_samples, n_features), and the return type is a tuple of integers.
- Checks are implemented to ensure that the input is a valid numpy array with a 2D shape. If not, a `ValueError` is raised.
- The function utilizes `np.unravel_index(np.argmax(X, axis=None), X.shape)` to efficiently find the row and column indices of the maximum value in the array.
- The result is returned as a tuple of integers representing the row and column indices.

The `wallis_product` function calculates an approximation of pi using the Wallis product formula. Here's a breakdown of the implementation:
- Type hints (annotations) have been added to the function signature to specify that the input parameter `n_terms` is expected to be an integer, and the return type is a float.
- The function starts by handling the special case where `n_terms` is 0, in which case it returns the convention value of 2.
- It then generates an array of terms using `np.arange`, calculates the numerators and denominators of the Wallis product formula, and computes the product using `np.prod`.
- The final result is the approximation of pi based on the specified number of terms in the Wallis product.

## `.gitignore`
- Add _.vscode_ to ignore folder.